### PR TITLE
feat: allow custom provider base URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,18 +86,23 @@ provider: "phind"
 
 phindApiKey: ""             # Phind does not require an API key by default
 phindModel: "Phind-70B"      # Current Phind model is free
+phindBaseURL: "https://https.extension.phind.com/agent/"
 
 openAiApiKey: "sk-YOUR-OPENAI-KEY"
 openaiModel: "gpt-4o-latest"
+openaiBaseURL: "https://api.openai.com/v1"
 
 googleApiKey: "YOUR-GOOGLE-KEY"
 googleModel: "models/google-2.0-flash"
+googleBaseURL: "https://generativelanguage.googleapis.com"
 
 anthropicApiKey: "sk-YOUR-ANTHROPIC-KEY"
 anthropicModel: "claude-3-5-sonnet-latest"
+anthropicBaseURL: "https://api.anthropic.com/v1"
 
 deepseekApiKey: "YOUR-DEEPSEEK-KEY"
 deepseekModel: "deepseek-chat"
+deepseekBaseURL: "https://api.deepseek.com/v1"
 
 ollamaBaseURL: "http://localhost:11434"
 ollamaModel: "llama2"
@@ -179,7 +184,7 @@ API Keys via Environment Variables:
 *   `--provider`: AI provider selection (`openai`, `google`, `anthropic`, `deepseek`, `phind`, `ollama`).
 *   `--model`: Specific model choice per provider (e.g., `gpt-4`, `models/google-2.0-flash`, `claude-3-5-sonnet-latest`, `deepseek-chat`, `Phind-70B`, `llama2`).
 *   `--apiKey`, `--googleApiKey`, `--anthropicApiKey`, `--deepseekApiKey`, `--phindApiKey`: API keys for each provider.
-*   `--ollamaBaseURL`: Base URL for Ollama provider (default: http://localhost:11434).
+*   `--openaiBaseURL`, `--googleBaseURL`, `--anthropicBaseURL`, `--deepseekBaseURL`, `--phindBaseURL`, `--ollamaBaseURL`: Base URLs for each provider (Ollama defaults to http://localhost:11434).
 *   `--commit-type`: Force a commit type (e.g., `fix`, `feat`) for non-interactive use or AI guidance.
 *   `--template`: Custom template for commit messages, wrapping AI output.
 *   `--prompt` *(Deprecated)*: Use `promptTemplate` in `config.yaml` for persistent prompt customization instead.

--- a/cmd/ai-commit/ai-commit.go
+++ b/cmd/ai-commit/ai-commit.go
@@ -42,6 +42,11 @@ var (
 	anthropicAPIKeyFlag  string
 	deepseekAPIKeyFlag   string
 	phindAPIKeyFlag      string
+	openaiBaseURLFlag    string
+	googleBaseURLFlag    string
+	anthropicBaseURLFlag string
+	deepseekBaseURLFlag  string
+	phindBaseURLFlag     string
 	ollamaBaseURLFlag    string
 	commitTypeFlag       string
 	templateFlag         string
@@ -81,6 +86,11 @@ func init() {
 	rootCmd.Flags().StringVar(&anthropicAPIKeyFlag, "anthropicApiKey", "", "API key for Anthropic provider (or env ANTHROPIC_API_KEY)")
 	rootCmd.Flags().StringVar(&deepseekAPIKeyFlag, "deepseekApiKey", "", "API key for Deepseek provider (or env DEEPSEEK_API_KEY)")
 	rootCmd.Flags().StringVar(&phindAPIKeyFlag, "phindApiKey", "", "API key for Phind provider (or env PHIND_API_KEY)")
+	rootCmd.Flags().StringVar(&openaiBaseURLFlag, "openaiBaseURL", "", "Base URL for OpenAI provider")
+	rootCmd.Flags().StringVar(&googleBaseURLFlag, "googleBaseURL", "", "Base URL for Google provider")
+	rootCmd.Flags().StringVar(&anthropicBaseURLFlag, "anthropicBaseURL", "", "Base URL for Anthropic provider")
+	rootCmd.Flags().StringVar(&deepseekBaseURLFlag, "deepseekBaseURL", "", "Base URL for Deepseek provider")
+	rootCmd.Flags().StringVar(&phindBaseURLFlag, "phindBaseURL", "", "Base URL for Phind provider")
 	rootCmd.Flags().StringVar(&ollamaBaseURLFlag, "ollamaBaseURL", "", "Base URL for Ollama provider")
 	rootCmd.Flags().StringVar(&commitTypeFlag, "commit-type", "", "Commit type (e.g., feat, fix)")
 	rootCmd.Flags().StringVar(&templateFlag, "template", "", "Commit message template")
@@ -187,7 +197,14 @@ func initAIClient(ctx context.Context, cfg *config.Config) (ai.AIClient, error) 
 		if modelFlag != "" {
 			model = modelFlag
 		}
-		return openai.NewOpenAIClient(key, model), nil
+		baseURL := cfg.OpenAIBaseURL
+		if openaiBaseURLFlag != "" {
+			baseURL = openaiBaseURLFlag
+		}
+		if baseURL == "" {
+			baseURL = config.DefaultOpenAIBaseURL
+		}
+		return openai.NewOpenAIClient(key, model, baseURL), nil
 
 	case "google":
 		key, err := config.ResolveAPIKey(googleAPIKeyFlag, "GOOGLE_API_KEY", cfg.GoogleAPIKey, "google")
@@ -198,7 +215,14 @@ func initAIClient(ctx context.Context, cfg *config.Config) (ai.AIClient, error) 
 		if modelFlag != "" {
 			model = modelFlag
 		}
-		googleClient, err := google.NewGoogleProClient(ctx, key, model)
+		baseURL := cfg.GoogleBaseURL
+		if googleBaseURLFlag != "" {
+			baseURL = googleBaseURLFlag
+		}
+		if baseURL == "" {
+			baseURL = config.DefaultGoogleBaseURL
+		}
+		googleClient, err := google.NewGoogleProClient(ctx, key, model, baseURL)
 		if err != nil {
 			return nil, fmt.Errorf("falha ao inicializar o cliente Google: %w", err)
 		}
@@ -213,7 +237,14 @@ func initAIClient(ctx context.Context, cfg *config.Config) (ai.AIClient, error) 
 		if modelFlag != "" {
 			model = modelFlag
 		}
-		anthroClient, err := anthropic.NewAnthropicClient(key, model)
+		baseURL := cfg.AnthropicBaseURL
+		if anthropicBaseURLFlag != "" {
+			baseURL = anthropicBaseURLFlag
+		}
+		if baseURL == "" {
+			baseURL = config.DefaultAnthropicBaseURL
+		}
+		anthroClient, err := anthropic.NewAnthropicClient(key, model, baseURL)
 		if err != nil {
 			return nil, fmt.Errorf("falha ao inicializar o cliente Anthropic: %w", err)
 		}
@@ -228,7 +259,14 @@ func initAIClient(ctx context.Context, cfg *config.Config) (ai.AIClient, error) 
 		if modelFlag != "" {
 			model = modelFlag
 		}
-		deepseekClient, err := deepseek.NewDeepseekClient(key, model)
+		baseURL := cfg.DeepseekBaseURL
+		if deepseekBaseURLFlag != "" {
+			baseURL = deepseekBaseURLFlag
+		}
+		if baseURL == "" {
+			baseURL = config.DefaultDeepseekBaseURL
+		}
+		deepseekClient, err := deepseek.NewDeepseekClient(key, model, baseURL)
 		if err != nil {
 			return nil, fmt.Errorf("falha ao inicializar o cliente Deepseek: %w", err)
 		}
@@ -243,7 +281,14 @@ func initAIClient(ctx context.Context, cfg *config.Config) (ai.AIClient, error) 
 		if modelFlag != "" {
 			model = modelFlag
 		}
-		return phind.NewPhindClient(key, model), nil
+		baseURL := cfg.PhindBaseURL
+		if phindBaseURLFlag != "" {
+			baseURL = phindBaseURLFlag
+		}
+		if baseURL == "" {
+			baseURL = config.DefaultPhindBaseURL
+		}
+		return phind.NewPhindClient(key, model, baseURL), nil
 
 	case "ollama":
 		baseURL := cfg.OllamaBaseURL

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -7,17 +7,25 @@ authorEmail: "youremail@example.com"
 # Which AI provider to use. Valid options: "openai", "google" or "anthropic"
 provider: "phind" # Current Phind model is free
 
-# Phind model to use.
+# Phind model and base URL.
 phindModel: "Phind-70B"
+phindBaseURL: "https://https.extension.phind.com/agent/"
 
 # OpenAI model to use.
 openaiModel: "gpt-4olatest"
+openaiBaseURL: "https://api.openai.com/v1"
 
 # Google model to use.
 googleModel: "models/gemini-2.5-flash"
+googleBaseURL: "https://generativelanguage.googleapis.com"
 
 # Anthropic model to use.
 anthropicModel: "claude-3-5-sonnet-latest"
+anthropicBaseURL: "https://api.anthropic.com/v1"
+
+# Deepseek model and base URL.
+deepseekModel: "deepseek-chat"
+deepseekBaseURL: "https://api.deepseek.com/v1"
 
 # API key for Phind. Overridden by the --phindApiKey flag or the PHIND_API_KEY environment variable.
 phindApiKey: "" # Phind does not require an API key by default

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,14 +11,19 @@ import (
 )
 
 const (
-	DefaultProvider       = "phind"
-	DefaultOpenAIModel    = "chatgpt-4o-latest"
-	DefaultGoogleModel    = "models/gemini-2.5-flash"
-	DefaultAnthropicModel = "claude-3-7-sonnet-latest"
-	DefaultDeepseekModel  = "deepseek-chat"
-	DefaultPhindModel     = "Phind-70B"
-	DefaultOllamaModel    = "llama2"
-	DefaultOllamaBaseURL  = "http://localhost:11434"
+	DefaultProvider         = "phind"
+	DefaultOpenAIModel      = "chatgpt-4o-latest"
+	DefaultGoogleModel      = "models/gemini-2.5-flash"
+	DefaultAnthropicModel   = "claude-3-7-sonnet-latest"
+	DefaultDeepseekModel    = "deepseek-chat"
+	DefaultPhindModel       = "Phind-70B"
+	DefaultOllamaModel      = "llama2"
+	DefaultOpenAIBaseURL    = "https://api.openai.com/v1"
+	DefaultGoogleBaseURL    = "https://generativelanguage.googleapis.com"
+	DefaultAnthropicBaseURL = "https://api.anthropic.com/v1"
+	DefaultDeepseekBaseURL  = "https://api.deepseek.com/v1"
+	DefaultPhindBaseURL     = "https://https.extension.phind.com/agent/"
+	DefaultOllamaBaseURL    = "http://localhost:11434"
 )
 
 var (
@@ -44,19 +49,24 @@ type Config struct {
 	CommitTypes      []CommitTypeConfig `yaml:"commitTypes,omitempty"`
 	LockFiles        []string           `yaml:"lockFiles,omitempty"`
 
-	OpenAIAPIKey    string `yaml:"openAiApiKey,omitempty"`
-	OpenAIModel     string `yaml:"openaiModel,omitempty"`
-	GoogleAPIKey    string `yaml:"googleApiKey,omitempty"`
-	GoogleModel     string `yaml:"googleModel,omitempty"`
-	AnthropicAPIKey string `yaml:"anthropicApiKey,omitempty"`
-	AnthropicModel  string `yaml:"anthropicModel,omitempty"`
-	DeepseekAPIKey  string `yaml:"deepseekApiKey,omitempty"`
-	DeepseekModel   string `yaml:"deepseekModel,omitempty"`
-	PhindAPIKey     string `yaml:"phindApiKey,omitempty"`
-	PhindModel      string `yaml:"phindModel,omitempty"`
-	OllamaBaseURL   string `yaml:"ollamaBaseURL,omitempty"`
-	OllamaModel     string `yaml:"ollamaModel,omitempty"`
-	PromptTemplate  string `yaml:"promptTemplate,omitempty"`
+	OpenAIAPIKey     string `yaml:"openAiApiKey,omitempty"`
+	OpenAIModel      string `yaml:"openaiModel,omitempty"`
+	OpenAIBaseURL    string `yaml:"openaiBaseURL,omitempty"`
+	GoogleAPIKey     string `yaml:"googleApiKey,omitempty"`
+	GoogleModel      string `yaml:"googleModel,omitempty"`
+	GoogleBaseURL    string `yaml:"googleBaseURL,omitempty"`
+	AnthropicAPIKey  string `yaml:"anthropicApiKey,omitempty"`
+	AnthropicModel   string `yaml:"anthropicModel,omitempty"`
+	AnthropicBaseURL string `yaml:"anthropicBaseURL,omitempty"`
+	DeepseekAPIKey   string `yaml:"deepseekApiKey,omitempty"`
+	DeepseekModel    string `yaml:"deepseekModel,omitempty"`
+	DeepseekBaseURL  string `yaml:"deepseekBaseURL,omitempty"`
+	PhindAPIKey      string `yaml:"phindApiKey,omitempty"`
+	PhindModel       string `yaml:"phindModel,omitempty"`
+	PhindBaseURL     string `yaml:"phindBaseURL,omitempty"`
+	OllamaBaseURL    string `yaml:"ollamaBaseURL,omitempty"`
+	OllamaModel      string `yaml:"ollamaModel,omitempty"`
+	PromptTemplate   string `yaml:"promptTemplate,omitempty"`
 
 	AuthorName  string `yaml:"authorName,omitempty"`
 	AuthorEmail string `yaml:"authorEmail,omitempty"`
@@ -86,22 +96,27 @@ func LoadOrCreateConfig() (*Config, error) {
 	// If config file does not exist, create a default config.
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		defaultCfg := &Config{
-			Provider:        DefaultProvider,
-			OpenAIAPIKey:    "",
-			OpenAIModel:     DefaultOpenAIModel,
-			GoogleAPIKey:    "",
-			GoogleModel:     DefaultGoogleModel,
-			AnthropicAPIKey: "",
-			AnthropicModel:  DefaultAnthropicModel,
-			DeepseekAPIKey:  "",
-			DeepseekModel:   DefaultDeepseekModel,
-			PhindAPIKey:     "",
-			PhindModel:      DefaultPhindModel,
-			OllamaBaseURL:   DefaultOllamaBaseURL,
-			OllamaModel:     DefaultOllamaModel,
-			AuthorName:      DefaultAuthorName,
-			AuthorEmail:     DefaultAuthorEmail,
-			LockFiles:       []string{"go.mod", "go.sum"},
+			Provider:         DefaultProvider,
+			OpenAIAPIKey:     "",
+			OpenAIModel:      DefaultOpenAIModel,
+			OpenAIBaseURL:    DefaultOpenAIBaseURL,
+			GoogleAPIKey:     "",
+			GoogleModel:      DefaultGoogleModel,
+			GoogleBaseURL:    DefaultGoogleBaseURL,
+			AnthropicAPIKey:  "",
+			AnthropicModel:   DefaultAnthropicModel,
+			AnthropicBaseURL: DefaultAnthropicBaseURL,
+			DeepseekAPIKey:   "",
+			DeepseekModel:    DefaultDeepseekModel,
+			DeepseekBaseURL:  DefaultDeepseekBaseURL,
+			PhindAPIKey:      "",
+			PhindModel:       DefaultPhindModel,
+			PhindBaseURL:     DefaultPhindBaseURL,
+			OllamaBaseURL:    DefaultOllamaBaseURL,
+			OllamaModel:      DefaultOllamaModel,
+			AuthorName:       DefaultAuthorName,
+			AuthorEmail:      DefaultAuthorEmail,
+			LockFiles:        []string{"go.mod", "go.sum"},
 			// Default commit types and emojis:
 			CommitTypes: []CommitTypeConfig{
 				{Type: "feat", Emoji: "✨"},

--- a/pkg/provider/anthropic/anthropic.go
+++ b/pkg/provider/anthropic/anthropic.go
@@ -16,11 +16,15 @@ type AnthropicClient struct {
 	model  string
 }
 
-func NewAnthropicClient(apiKey, model string) (*AnthropicClient, error) {
+func NewAnthropicClient(apiKey, model, baseURL string) (*AnthropicClient, error) {
 	if apiKey == "" {
 		return nil, errors.New("anthropic API key is required")
 	}
-	client := anthropicSDK.NewClient(apiKey)
+	opts := []anthropicSDK.ClientOption{}
+	if strings.TrimSpace(baseURL) != "" {
+		opts = append(opts, anthropicSDK.WithBaseURL(baseURL))
+	}
+	client := anthropicSDK.NewClient(apiKey, opts...)
 	if client == nil {
 		return nil, errors.New("failed to create Anthropic client")
 	}

--- a/pkg/provider/deepseek/deepseek.go
+++ b/pkg/provider/deepseek/deepseek.go
@@ -16,7 +16,7 @@ type DeepseekClient struct {
 	model  string
 }
 
-func NewDeepseekClient(apiKey, model string) (*DeepseekClient, error) {
+func NewDeepseekClient(apiKey, model, baseURL string) (*DeepseekClient, error) {
 	if apiKey == "" {
 		return nil, errors.New("deepseek API key is required")
 	}
@@ -24,9 +24,13 @@ func NewDeepseekClient(apiKey, model string) (*DeepseekClient, error) {
 		return nil, errors.New("deepseek model is required")
 	}
 
-	config := gogpt.DefaultConfig(apiKey)
-	config.BaseURL = "https://api.deepseek.com/v1"
-	client := gogpt.NewClientWithConfig(config)
+	cfg := gogpt.DefaultConfig(apiKey)
+	if strings.TrimSpace(baseURL) != "" {
+		cfg.BaseURL = baseURL
+	} else {
+		cfg.BaseURL = "https://api.deepseek.com/v1"
+	}
+	client := gogpt.NewClientWithConfig(cfg)
 
 	return &DeepseekClient{
 		BaseAIClient: ai.BaseAIClient{Provider: "deepseek"},

--- a/pkg/provider/google/google.go
+++ b/pkg/provider/google/google.go
@@ -3,6 +3,7 @@ package google
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/generative-ai-go/genai"
 	"google.golang.org/api/option"
@@ -22,8 +23,12 @@ func NewClient(client *genai.GenerativeModel) *GoogleClient {
 	}
 }
 
-func NewGoogleProClient(ctx context.Context, apiKey string, modelName string) (*genai.GenerativeModel, error) {
-	client, err := genai.NewClient(ctx, option.WithAPIKey(apiKey))
+func NewGoogleProClient(ctx context.Context, apiKey string, modelName string, baseURL string) (*genai.GenerativeModel, error) {
+	opts := []option.ClientOption{option.WithAPIKey(apiKey)}
+	if strings.TrimSpace(baseURL) != "" {
+		opts = append(opts, option.WithEndpoint(baseURL))
+	}
+	client, err := genai.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating google client: %w", err)
 	}

--- a/pkg/provider/openai/openai.go
+++ b/pkg/provider/openai/openai.go
@@ -17,10 +17,14 @@ type OpenAIClient struct {
 	model  string
 }
 
-func NewOpenAIClient(key, model string) *OpenAIClient {
+func NewOpenAIClient(key, model, baseURL string) *OpenAIClient {
+	cfg := gogpt.DefaultConfig(key)
+	if strings.TrimSpace(baseURL) != "" {
+		cfg.BaseURL = baseURL
+	}
 	return &OpenAIClient{
 		BaseAIClient: ai.BaseAIClient{Provider: "openai"}, // Initialize base client
-		client:       gogpt.NewClient(key),
+		client:       gogpt.NewClientWithConfig(cfg),
 		model:        model,
 	}
 }

--- a/pkg/provider/phind/phind.go
+++ b/pkg/provider/phind/phind.go
@@ -20,9 +20,12 @@ type PhindClient struct {
 	token      string
 }
 
-func NewPhindClient(token, model string) *PhindClient {
+func NewPhindClient(token, model, baseURL string) *PhindClient {
 	if model == "" {
 		model = "Phind-70B"
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = "https://https.extension.phind.com/agent/"
 	}
 	return &PhindClient{
 		BaseAIClient: ai.BaseAIClient{Provider: "phind"},
@@ -30,7 +33,7 @@ func NewPhindClient(token, model string) *PhindClient {
 			Timeout: 60 * time.Second,
 		},
 		model:      model,
-		apiBaseURL: "https://https.extension.phind.com/agent/",
+		apiBaseURL: baseURL,
 		token:      token,
 	}
 }


### PR DESCRIPTION
## Summary
- allow setting base URLs for OpenAI, Google, Anthropic, Deepseek, Phind and Ollama
- expose CLI flags and config fields for customizing provider endpoints
- document base URL options in README and example config

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7400dec8883298f44245934fe8eac